### PR TITLE
feat(log-columns): add select_source field for dynamic select options

### DIFF
--- a/server/flyway/sql/V65__add_select_source_to_log_columns.sql
+++ b/server/flyway/sql/V65__add_select_source_to_log_columns.sql
@@ -1,0 +1,162 @@
+-- =========================================
+-- V65: Add select_source to log_columns Table
+-- =========================================
+-- Description: Adds a nullable select_source column to log_columns to identify
+--              which data source provides the options for select-type columns
+--              (select_simple, select_multiple). This enables the frontend to
+--              dynamically fetch the correct options for each select input without
+--              hardcoding the source per column name.
+--
+-- Prerequisites:
+--   - V51 migration must have been successfully applied (log_columns table exists)
+--   - V62 migration must have been successfully applied (select_simple and select_multiple added to column_log_type enum)
+--   - flyway_admin role exists with appropriate permissions
+--   - prisma_user role exists for application-level access
+--
+-- Business Impact:
+--   - Enables dynamic select inputs in forms driven by log column metadata
+--   - Decouples the frontend from hardcoded column-to-source mappings
+--   - Supports multiple entities reusing the same select sources (programmingLanguages, externalDependencies, subtypes)
+--   - Only relevant for columns of type select_simple or select_multiple; NULL for all other types
+--
+-- Safety Measures:
+--   - Column is nullable: existing rows (text, number, boolean) are unaffected
+--   - VARCHAR(50) limits the value to known source identifiers
+--   - No FK constraint: source identifiers are logical names, not DB references
+--   - Defensive programming with existence checks
+--
+-- PostgreSQL Best Practices Applied:
+--   - snake_case column name following project conventions
+--   - Nullable column for additive, non-breaking change
+--   - Comprehensive documentation via comments
+--   - Permission grants following least privilege principle
+-- =========================================
+
+-- =========================================
+-- STEP 1: Validate Prerequisites
+-- =========================================
+
+-- Verify log_columns table exists
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.tables
+        WHERE table_schema = 'public'
+        AND table_name = 'log_columns'
+    ) THEN
+        RAISE EXCEPTION 'Prerequisites not met: log_columns table does not exist. V51 migration must be applied first.';
+    END IF;
+END $$;
+
+-- Verify flyway_admin role exists
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_roles
+        WHERE rolname = 'flyway_admin'
+    ) THEN
+        RAISE EXCEPTION 'Prerequisites not met: flyway_admin role does not exist.';
+    END IF;
+END $$;
+
+-- Verify prisma_user role exists
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_roles
+        WHERE rolname = 'prisma_user'
+    ) THEN
+        RAISE WARNING 'prisma_user role does not exist. Permission grants will be skipped.';
+    END IF;
+END $$;
+
+-- =========================================
+-- STEP 2: Add select_source Column
+-- =========================================
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public'
+        AND table_name = 'log_columns'
+        AND column_name = 'select_source'
+    ) THEN
+        ALTER TABLE public.log_columns
+        ADD COLUMN select_source VARCHAR(50) NULL;
+
+        RAISE NOTICE 'Column select_source added to log_columns table';
+    ELSE
+        RAISE NOTICE 'Column select_source already exists, skipping addition';
+    END IF;
+END $$;
+
+-- =========================================
+-- STEP 3: Add Documentation
+-- =========================================
+
+COMMENT ON COLUMN public.log_columns.select_source IS
+'Identifies the data source that provides options for select-type columns
+(select_simple, select_multiple). NULL for text, number, and boolean columns.
+Known values: programmingLanguages, externalDependencies, subtypes.
+This is a logical identifier used by the frontend to fetch the correct options
+dynamically — it does not reference a database table directly.';
+
+-- =========================================
+-- STEP 4: Validation and Verification
+-- =========================================
+
+-- Verify column was added successfully
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public'
+        AND table_name = 'log_columns'
+        AND column_name = 'select_source'
+        AND is_nullable = 'YES'
+    ) THEN
+        RAISE WARNING 'Column verification failed: select_source column not found or has incorrect nullability';
+    ELSE
+        RAISE NOTICE 'Success: select_source column verified (NULLABLE VARCHAR(50))';
+    END IF;
+END $$;
+
+-- =========================================
+-- MIGRATION SUMMARY AND USAGE NOTES
+-- =========================================
+-- This migration adds a nullable select_source column to log_columns:
+--
+-- 1. SCHEMA CHANGES APPLIED:
+--    - Added column: select_source VARCHAR(50) NULL to public.log_columns
+--
+-- 2. COLUMN PURPOSE:
+--    - Only meaningful when type = 'select_simple' or 'select_multiple'
+--    - NULL for type = 'text', 'number', 'boolean'
+--    - Known source values at time of migration:
+--      * 'programmingLanguages' -> programming_languages table
+--      * 'externalDependencies' -> external_dependencies table
+--      * 'subtypes'             -> subtypes table
+--
+-- 3. SEEDING EXISTING SELECT COLUMNS:
+--    After applying this migration, update existing select-type rows:
+--
+--    UPDATE public.log_columns
+--    SET select_source = 'programmingLanguages'
+--    WHERE name = 'programming_language_id'
+--    AND type IN ('select_simple'::column_log_type, 'select_multiple'::column_log_type);
+--
+--    UPDATE public.log_columns
+--    SET select_source = 'externalDependencies'
+--    WHERE name = 'external_dependency_id'
+--    AND type IN ('select_simple'::column_log_type, 'select_multiple'::column_log_type);
+--
+--    UPDATE public.log_columns
+--    SET select_source = 'subtypes'
+--    WHERE name IN ('commit_type_id', 'commit_scope_id')
+--    AND type IN ('select_simple'::column_log_type, 'select_multiple'::column_log_type);
+--
+-- 4. ROLLBACK PROCEDURE (If Needed):
+--    ALTER TABLE public.log_columns
+--    DROP COLUMN IF EXISTS select_source;
+--

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -182,6 +182,7 @@ model logColumns {
   name                   String
   type                   columnLogType
   logTypeId            String                   @map("log_type_id") @db.Uuid
+  selectSource         String?                  @map("select_source") @db.VarChar(50)
   logColumnValidations logColumnValidations[]
   logTypes              logTypes                @relation(fields: [logTypeId], references: [id], onDelete: Cascade, map: "fk_log_columns_log_type_id")
 

--- a/server/src/action-logs/dto/log-columns-response.dto.ts
+++ b/server/src/action-logs/dto/log-columns-response.dto.ts
@@ -1,10 +1,11 @@
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 import {
   IsArray,
   IsBoolean,
   IsEnum,
   IsNotEmpty,
+  IsOptional,
   IsString,
   IsUUID,
   ValidateNested,
@@ -95,11 +96,11 @@ export class LogColumnResponseDto {
   @ApiProperty({
     description: 'Column data type (read-only configuration)',
     example: 'text',
-    enum: ['text', 'number', 'boolean'],
+    enum: ['text', 'number', 'boolean', 'select_simple', 'select_multiple'],
   })
-  @IsEnum(['text', 'number', 'boolean'])
+  @IsEnum(['text', 'number', 'boolean', 'select_simple', 'select_multiple'])
   @IsNotEmpty()
-  type!: 'text' | 'number' | 'boolean';
+  type!: 'text' | 'number' | 'boolean' | 'select_simple' | 'select_multiple';
 
   @ApiProperty({
     description: 'Log type ID this column belongs to (read-only)',
@@ -110,6 +111,17 @@ export class LogColumnResponseDto {
   @IsUUID()
   @IsNotEmpty()
   logTypeId!: UUID;
+
+  @ApiPropertyOptional({
+    description:
+      'Identifies the data source for select-type columns. Present only when type is select_simple or select_multiple.',
+    example: 'programmingLanguages',
+    type: String,
+    nullable: true,
+  })
+  @IsOptional()
+  @IsString()
+  selectSource?: string | null;
 
   @ApiProperty({
     description:

--- a/server/src/action-logs/repositories/action-logs.repository.ts
+++ b/server/src/action-logs/repositories/action-logs.repository.ts
@@ -256,6 +256,7 @@ export class ActionLogsRepository implements IActionLogsRepository {
           name: string;
           type: string;
           logTypeId: string;
+          selectSource: string | null;
           logColumnValidations: Array<{
             id: string;
             validationFunctionId: string;
@@ -320,6 +321,7 @@ export class ActionLogsRepository implements IActionLogsRepository {
     name: string;
     type: string;
     logTypeId: string;
+    selectSource: string | null;
     logColumnValidations: Array<{
       id: string;
       validationFunctionId: string;
@@ -344,8 +346,9 @@ export class ActionLogsRepository implements IActionLogsRepository {
     return {
       id: data.id,
       name: this.snakeToCamel(data.name),
-      type: data.type as 'text' | 'number' | 'boolean',
+      type: data.type as 'text' | 'number' | 'boolean' | 'select_simple' | 'select_multiple',
       logTypeId: data.logTypeId,
+      selectSource: data.selectSource,
       validations,
     };
   }


### PR DESCRIPTION
Add support for identifying data sources in select-type columns. This enables the frontend to dynamically fetch options without hardcoding column-to-source mappings.

Changes:
- Extended logColumns schema with nullable selectSource field
- Updated LogColumnResponseDto to support select_simple and select_multiple types
- Added selectSource to type enum and response mapping in ActionLogsRepository
- Created Flyway migration V65 for database schema evolution with comprehensive documentation and safety measures