### PR TITLE
fix(typescript): resolve nullable icon field type errors

### DIFF
--- a/server/src/action-types/repositories/action-types.repository.ts
+++ b/server/src/action-types/repositories/action-types.repository.ts
@@ -45,7 +45,7 @@ export class ActionTypesRepository implements IActionTypesRepository {
       const globalIdentifier = await this.prisma.globalEntityIdentifiers.create({
         data: {
           name: data.name,
-          icon: data.icon,
+          icon: data.icon ?? null,
           entityType: 'action_type',
           entityId: createdActionType.id,
         },

--- a/server/src/habits/dto/habit-response.dto.ts
+++ b/server/src/habits/dto/habit-response.dto.ts
@@ -27,7 +27,7 @@ export class HabitResponseDto {
     example:
       'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==',
   })
-  icon!: string;
+  icon!: string | null;
 
   @ApiProperty({
     description: 'Whether the habit is active',

--- a/server/src/habits/services/habits.service.ts
+++ b/server/src/habits/services/habits.service.ts
@@ -200,7 +200,7 @@ export class HabitsService {
         // Name updated but not icon, include existing icon
         dataToUpdate = {
           ...updateData,
-          icon: existingHabit.globalEntityIdentifier.icon.getValue(),
+          icon: existingHabit.globalEntityIdentifier.icon?.getValue() ?? null,
         };
       } else {
         // Icon updated (with or without name update)
@@ -242,7 +242,7 @@ export class HabitsService {
       id: habit.id,
       name: habit.globalEntityIdentifier.name.getValue(),
       habitType: habit.habitType,
-      icon: habit.globalEntityIdentifier.icon.getValue(),
+      icon: habit.globalEntityIdentifier.icon?.getValue() ?? null,
       isActive: habit.isActive,
       totalActionsCount: habit.totalActionsCount,
       lastActionDate: habit.lastActionDate ? new Date(habit.lastActionDate) : null,


### PR DESCRIPTION
Handle nullable icon fields across the habits and action-types modules:
- Use optional chaining and nullish coalescing in habits.service to safely access potentially null icon values
- Update habit-response.dto icon type to string | null to reflect database schema
- Coerce undefined to null in action-types.repository for Prisma compatibility

These changes ensure TypeScript compilation succeeds while maintaining type safety with nullable icon fields introduced in the database schema.